### PR TITLE
alias u32 and u64 in userspace

### DIFF
--- a/gen_ioctls_list.sh
+++ b/gen_ioctls_list.sh
@@ -81,6 +81,9 @@ get_c_file() {
     echo '#include "ioctls_list.h"'
     echo '#include <asm/termbits.h>' # struct termios2
     echo '#include <linux/types.h>'  # other types
+    echo 
+    echo 'typedef __u32 u32;'
+    echo 'typedef __u64 u64;'
     # Place your extra headers here
     echo
     show_includes "$HEADERS"


### PR DESCRIPTION
Hello

When I run `./gen_ioctls_list.sh` on my x86_64 machine with v5.15 kernel, 
it successfully detects the presence of `linux/dma-buf.h` header.

However, since those entries use `u32` and `u64` types from kernel space, 
I get a compilation error:

```
gcc -Wall   -c -MMD -c -o ioctls_list.o ioctls_list.c
In file included from /usr/include/x86_64-linux-gnu/asm/ioctl.h:1,
                 from /usr/include/linux/ioctl.h:5,
                 from /usr/include/asm-generic/ioctls.h:5,
                 from ioctls_list.c:11:
ioctls_list.c:463:29: error: ‘u32’ undeclared here (not in a function)
  463 |     { "DMA_BUF_SET_NAME_A", DMA_BUF_SET_NAME_A, -1, -1 }, // linux/dma-buf.h
      |                             ^~~~~~~~~~~~~~~~~~
ioctls_list.c:464:29: error: ‘u64’ undeclared here (not in a function)
  464 |     { "DMA_BUF_SET_NAME_B", DMA_BUF_SET_NAME_B, -1, -1 }, // linux/dma-buf.h
      |                             ^~~~~~~~~~~~~~~~~~
make: *** [Makefile:22: ioctls_list.o] Error 1
```
Since `typedef`s are checked for collision during compilation, I think that 
this is not a very ugly hack.

Any comments are welcome of course.